### PR TITLE
Check status of shard before starting migrations

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 2, 5)
+VERSION = (0, 2, 6)

--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 2, 6)
+VERSION = (0, 2, 7)

--- a/shardmonster/api.py
+++ b/shardmonster/api.py
@@ -117,6 +117,18 @@ def start_migration(realm, shard_key, new_location):
     """Marks a shard as being in the process of being migrated.
     """
     shards_coll = _get_shards_coll()
+
+    shard_metas = list(
+        shards_coll.find({'realm': realm, 'shard_key': shard_key},))
+
+    if not shard_metas:
+        raise Exception(
+            'Could not find shard metadata - use set_shard_at_rest first')
+
+    shard_meta, = shard_metas
+    if shard_meta['location'] == new_location:
+        raise Exception('Shard is already at %s' % (new_location,))
+
     shards_coll.update(
         {'realm': realm, 'shard_key': shard_key},
         {'$set': {

--- a/shardmonster/operations.py
+++ b/shardmonster/operations.py
@@ -1,6 +1,7 @@
 """Contains everything to do with making Mongo operations work across multiple
 clusters.
 """
+import numbers
 import time
 
 from shardmonster.connection import get_connection
@@ -197,7 +198,8 @@ def _get_query_target(collection_name, query):
     realm = _get_realm_for_collection(collection_name)
     shard_field = realm['shard_field']
 
-    if shard_field in query and isinstance(query[shard_field], (basestring, int)):
+    if shard_field in query and \
+            isinstance(query[shard_field], (basestring, numbers.Integral)):
         return query[shard_field]
     return None
 


### PR DESCRIPTION
* Gives more informative errors before a migration starts
* Prompts user to use set_shard_at_rest first before attempting
  migration
* Prevents data loss caused by migrating a shard to the same location