### PR TITLE
Fix for using the wrong oplog

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 3, 15)
+VERSION = (0, 3, 16)


### PR DESCRIPTION
In environments where the controller is NOT the same as any of
the data stores the oplog will be totally different and not a
source of data we want to replica.

This includes fixes for the test integration suite to expose
this error