### PR TITLE
Fix for objects moving in the index during a copy

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 4, 3)
+VERSION = (0, 5, 0)


### PR DESCRIPTION
During a migration we iterate over the source collection and
Mongo will choose an index for us. If an object moves in the index
from being ahead of the cursor to being behind the cursor (the
cursor being what we are using to iterate over the source collection)
then the document will be skipped.

To fix this we check for existence before doing any updates from
the oplog and copy the documents across if they were missed.