### PR TITLE
Do not block main thread by default

### DIFF
--- a/shardmonster/__init__.py
+++ b/shardmonster/__init__.py
@@ -12,4 +12,4 @@ __all__ = [
     'where_is', 'wipe_metadata', 'VERSION',
 ]
 
-VERSION = (0, 5, 6)
+VERSION = (0, 6, 0)

--- a/shardmonster/tests/test_sharder.py
+++ b/shardmonster/tests/test_sharder.py
@@ -1,3 +1,4 @@
+from mock import Mock
 from shardmonster import api, sharder
 from shardmonster.tests.base import ShardingTestCase
 
@@ -20,7 +21,8 @@ class TestSharder(ShardingTestCase):
 
         api.start_migration('dummy', 1, "dest2/test_sharding")
 
-        sharder._do_copy('dummy', 1)
+        manager = Mock(insert_throttle=None)
+        sharder._do_copy('dummy', 1, manager)
 
         # The data should now be on the second database
         doc2, = self.db2.dummy.find({})
@@ -63,7 +65,8 @@ class TestSharder(ShardingTestCase):
 
         api.set_shard_to_migration_status(
             'dummy', 1, api.ShardStatus.POST_MIGRATION_DELETE)
-        sharder._delete_source_data('dummy', 1)
+        manager = Mock(delete_throttle=None)
+        sharder._delete_source_data('dummy', 1, manager)
 
         # The data on the first database should now be gone and the data
         # on the second database should be ok.


### PR DESCRIPTION
Instead of blocking the main thread when doing a migration return a
manager object that can be used to tweak throttles and can also
be blocked upon if desired.

This allows for migrations that are causing performance issues to
be reined in without stopping them entirely